### PR TITLE
chore: Add .gitignore to exclude unnecessary files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+docs/
+coverage/
+.DS_Store


### PR DESCRIPTION
### **Description**:
This PR adds a `.gitignore` file to exclude common files and directories (such as build artifacts in `dist`, `node_modules` etc.) from version control.

### **Why**:
To keep the repository clean by ensuring only relevant files are tracked and to avoid potential issues with unnecessary or sensitive files being included.
