### PR TITLE
Added Release-2 related screen support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+docs/
+coverage/
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ const Signup = React.lazy(() => import("./screens/Signup"));
 const ResetPasswordRequest = React.lazy(() => import("./screens/ResetPasswordRequest"));
 const ResetPasswordEmail = React.lazy(() => import("./screens/ResetPasswordEmail"));
 const ResetPassword = React.lazy(() => import("./screens/ResetPassword"));
-
+const ResetPasswordError = React.lazy(() => import("./screens/ResetPasswordError"));
+const ResetPasswordSuccess = React.lazy(() => import("./screens/ResetPasswordSuccess"));
 
 const App: React.FC = () => {
   const [screen, setScreen] = React.useState("login-id");
@@ -33,6 +34,10 @@ const App: React.FC = () => {
         return <ResetPasswordEmail />;
       case "reset-password":
         return <ResetPassword />;
+      case "reset-password-error":
+        return <ResetPasswordError />;
+      case "reset-password-success":
+        return <ResetPasswordSuccess />;
       default:
         return <>No screen rendered</>;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ const LoginIdScreen = React.lazy(() => import("./screens/LoginId"));
 const LoginPasswordScreen = React.lazy(() => import("./screens/LoginPassword"));
 const Login = React.lazy(() => import("./screens/Login"));
 const Signup = React.lazy(() => import("./screens/Signup"));
+const ResetPasswordRequest = React.lazy(() => import("./screens/ResetPasswordRequest"));
 
 
 const App: React.FC = () => {
@@ -24,6 +25,8 @@ const App: React.FC = () => {
         return <Login />; 
       case "signup":
         return <Signup />;
+      case "reset-password-request":
+        return <ResetPasswordRequest />;
       default:
         return <>No screen rendered</>;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { getCurrentScreen } from "@auth0/auth0-acul-js";
 const LoginIdScreen = React.lazy(() => import("./screens/LoginId"));
 const LoginPasswordScreen = React.lazy(() => import("./screens/LoginPassword"));
 const Login = React.lazy(() => import("./screens/Login"));
+const Signup = React.lazy(() => import("./screens/Signup"));
 
 
 const App: React.FC = () => {
@@ -21,6 +22,8 @@ const App: React.FC = () => {
         return <LoginPasswordScreen />;
       case "login":
         return <Login />; 
+      case "signup":
+        return <Signup />;
       default:
         return <>No screen rendered</>;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { getCurrentScreen } from "@auth0/auth0-acul-js";
 
 const LoginIdScreen = React.lazy(() => import("./screens/LoginId"));
 const LoginPasswordScreen = React.lazy(() => import("./screens/LoginPassword"));
+const Login = React.lazy(() => import("./screens/Login"));
+
 
 const App: React.FC = () => {
   const [screen, setScreen] = React.useState("login-id");
@@ -17,6 +19,8 @@ const App: React.FC = () => {
         return <LoginIdScreen />;
       case "login-password":
         return <LoginPasswordScreen />;
+      case "login":
+        return <Login />; 
       default:
         return <>No screen rendered</>;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ const Login = React.lazy(() => import("./screens/Login"));
 const Signup = React.lazy(() => import("./screens/Signup"));
 const ResetPasswordRequest = React.lazy(() => import("./screens/ResetPasswordRequest"));
 const ResetPasswordEmail = React.lazy(() => import("./screens/ResetPasswordEmail"));
+const ResetPassword = React.lazy(() => import("./screens/ResetPassword"));
 
 
 const App: React.FC = () => {
@@ -30,6 +31,8 @@ const App: React.FC = () => {
         return <ResetPasswordRequest />;
       case "reset-password-email":
         return <ResetPasswordEmail />;
+      case "reset-password":
+        return <ResetPassword />;
       default:
         return <>No screen rendered</>;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ const LoginPasswordScreen = React.lazy(() => import("./screens/LoginPassword"));
 const Login = React.lazy(() => import("./screens/Login"));
 const Signup = React.lazy(() => import("./screens/Signup"));
 const ResetPasswordRequest = React.lazy(() => import("./screens/ResetPasswordRequest"));
+const ResetPasswordEmail = React.lazy(() => import("./screens/ResetPasswordEmail"));
 
 
 const App: React.FC = () => {
@@ -27,6 +28,8 @@ const App: React.FC = () => {
         return <Signup />;
       case "reset-password-request":
         return <ResetPasswordRequest />;
+      case "reset-password-email":
+        return <ResetPasswordEmail />;
       default:
         return <>No screen rendered</>;
     }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,10 +4,11 @@ import '../styles/mixins.scss';
 interface ButtonProps {
   onClick: () => void;
   children: React.ReactNode;
+  id?: string;
 }
 
-const Button: React.FC<ButtonProps> = ({ onClick, children }) => (
-  <button className="button" onClick={onClick}>
+const Button: React.FC<ButtonProps> = ({ onClick, children, id }) => (
+  <button id={id} className="button" onClick={onClick}>
     {children}
   </button>
 );

--- a/src/components/ErrorMessages.tsx
+++ b/src/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -1,0 +1,9 @@
+interface LinksProps {
+  loginLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ loginLink }) => (
+  <div className="links">
+    {loginLink && <a href={loginLink}>Sign Up</a>}
+  </div>
+); 

--- a/src/components/SocialLogin.tsx
+++ b/src/components/SocialLogin.tsx
@@ -1,0 +1,22 @@
+import  Button  from './Button';
+interface Connection {
+  name: string;
+}
+
+interface SocialLoginProps {
+  connections?: Connection[];
+  onSocialLogin: (name: string) => void;
+}
+
+export const SocialLogin: React.FC<SocialLoginProps> = ({ connections, onSocialLogin }) => (
+  <div className="federated-login-container">
+    {connections?.map((connection) => (
+      <Button
+        key={connection.name}
+        onClick={() => onSocialLogin(connection.name)}
+      >
+        Continue with {connection.name}
+      </Button>
+    ))}
+  </div>
+); 

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,6 @@ const rootElement = document.createElement("div");
 rootElement.id = "root";
 
 document.body.appendChild(rootElement);
-document.body.style.overflow = "hidden";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/screens/Login/components/ErrorMessages.tsx
+++ b/src/screens/Login/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/screens/Login/components/Links.tsx
+++ b/src/screens/Login/components/Links.tsx
@@ -1,0 +1,11 @@
+interface LinksProps {
+  signupLink?: string;
+  resetPasswordLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ signupLink, resetPasswordLink }) => (
+  <div className="links">
+    {signupLink && <a href={signupLink}>Sign Up</a>}
+    {resetPasswordLink && <a href={resetPasswordLink}>Forgot Password?</a>}
+  </div>
+); 

--- a/src/screens/Login/components/LoginForm.tsx
+++ b/src/screens/Login/components/LoginForm.tsx
@@ -1,0 +1,59 @@
+import  Button  from '../../../components/Button';
+interface LoginFormProps {
+  usernameRef: React.RefObject<HTMLInputElement>;
+  passwordRef: React.RefObject<HTMLInputElement>;
+  captchaRef: React.RefObject<HTMLInputElement>;
+  isCaptchaAvailable: boolean;
+  captchaImage?: string;
+  countryCode?: string;
+  countryPrefix?: string;
+  onLoginClick: () => void;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({
+  usernameRef,
+  passwordRef,
+  captchaRef,
+  isCaptchaAvailable,
+  captchaImage,
+  countryCode,
+  countryPrefix,
+  onLoginClick,
+}) => (
+  <div className="input-container">
+    <button className="pick-country-code hidden" id="pick-country-code">
+      Pick country code - {countryCode}: +{countryPrefix}
+    </button>
+    <label>Enter your email</label>
+    <input
+      type="text"
+      id="username"
+      ref={usernameRef}
+      placeholder="Enter your email"
+    />
+    <label>Enter your password</label>
+    <input
+      type="password"
+      id="password"
+      ref={passwordRef}
+      placeholder="Enter your password"
+    />
+
+    {isCaptchaAvailable && (
+      <div className="captcha-container">
+        <img src={captchaImage ?? ""} alt="Captcha" />
+        <label>Enter the captcha</label>
+        <input
+          type="text"
+          id="captcha"
+          ref={captchaRef}
+          placeholder="Enter the captcha"
+        />
+      </div>
+    )}
+
+    <div className="button-container">
+      <Button onClick={onLoginClick}>Continue</Button>
+    </div>
+  </div>
+); 

--- a/src/screens/Login/components/SocialLogin.tsx
+++ b/src/screens/Login/components/SocialLogin.tsx
@@ -1,0 +1,22 @@
+import  Button  from '../../../components/Button';
+interface Connection {
+  name: string;
+}
+
+interface SocialLoginProps {
+  connections?: Connection[];
+  onSocialLogin: (name: string) => void;
+}
+
+export const SocialLogin: React.FC<SocialLoginProps> = ({ connections, onSocialLogin }) => (
+  <div className="federated-login-container">
+    {connections?.map((connection) => (
+      <Button
+        key={connection.name}
+        onClick={() => onSocialLogin(connection.name)}
+      >
+        Continue with {connection.name}
+      </Button>
+    ))}
+  </div>
+); 

--- a/src/screens/Login/components/Title.tsx
+++ b/src/screens/Login/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/screens/Login/hooks/useLoginForm.ts
+++ b/src/screens/Login/hooks/useLoginForm.ts
@@ -1,0 +1,20 @@
+import { useRef } from 'react';
+
+export const useLoginForm = () => {
+  const usernameRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const captchaRef = useRef<HTMLInputElement>(null);
+
+  const getFormValues = () => ({
+    username: usernameRef.current?.value ?? "",
+    password: passwordRef.current?.value ?? "",
+    captcha: captchaRef.current?.value ?? "",
+  });
+
+  return {
+    usernameRef,
+    passwordRef,
+    captchaRef,
+    getFormValues,
+  };
+};

--- a/src/screens/Login/hooks/useLoginManager.ts
+++ b/src/screens/Login/hooks/useLoginManager.ts
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import LoginInstance from "@auth0/auth0-acul-js/login";
+import { withWindowDebug } from "../../../utils";
 
 export const useLoginManager = () => {
   const [loginIdManager] = useState(() => new LoginInstance());
+  withWindowDebug(loginIdManager, 'login')
 
   const handleLogin = (username: string, password: string, captcha: string): void => {
     const options = {

--- a/src/screens/Login/hooks/useLoginManager.ts
+++ b/src/screens/Login/hooks/useLoginManager.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import LoginInstance from "@auth0/auth0-acul-js/login";
+
+export const useLoginManager = () => {
+  const [loginIdManager] = useState(() => new LoginInstance());
+
+  const handleLogin = (username: string, password: string, captcha: string): void => {
+    const options = {
+      username,
+      password,
+      captcha: loginIdManager.screen.isCaptchaAvailable ? captcha : "",
+    };
+    loginIdManager.login(options);
+  };
+
+  const handleSocialConnectionLogin = (connectionName: string) => {
+    loginIdManager.socialLogin({ connection: connectionName });
+  };
+
+  return {
+    loginIdManager,
+    handleLogin,
+    handleSocialConnectionLogin
+  };
+};
+

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -1,21 +1,20 @@
 import React from "react";
-import { useLoginIdManager } from './hooks/useLoginIdManager';
+import { useLoginManager } from './hooks/useLoginManager';
 import { useLoginForm } from './hooks/useLoginForm';
 import { Logo } from "../../components/Logo";
 import { Title } from './components/Title';
 import { LoginForm } from './components/LoginForm';
 import { SocialLogin } from './components/SocialLogin';
-import { PasskeyButton } from './components/PasskeyButton';
 import { Links } from './components/Links';
 import { ErrorMessages } from './components/ErrorMessages';
 
-const LoginIdScreen: React.FC = () => {
-  const { loginIdManager, handleLogin, handleSocialConnectionLogin, handlePasskeyLogin } = useLoginIdManager();
-  const { usernameRef, captchaRef, getFormValues } = useLoginForm();
+const LoginScreen: React.FC = () => {
+  const { loginIdManager, handleLogin, handleSocialConnectionLogin } = useLoginManager();
+  const { usernameRef, passwordRef, captchaRef, getFormValues } = useLoginForm();
 
   const onLoginClick = () => {
-    const { username, captcha } = getFormValues();
-    handleLogin(username, captcha);
+    const { username, password, captcha } = getFormValues();
+    handleLogin(username, password, captcha);
   };
 
   return (
@@ -25,6 +24,7 @@ const LoginIdScreen: React.FC = () => {
       
       <LoginForm
         usernameRef={usernameRef}
+        passwordRef={passwordRef}
         captchaRef={captchaRef}
         isCaptchaAvailable={loginIdManager.screen.isCaptchaAvailable}
         captchaImage={loginIdManager.screen.captchaImage!}
@@ -37,8 +37,6 @@ const LoginIdScreen: React.FC = () => {
         connections={loginIdManager.transaction.alternateConnections!}
         onSocialLogin={handleSocialConnectionLogin}
       />
-
-      <PasskeyButton onPasskeyLogin={handlePasskeyLogin} />
 
       {loginIdManager.screen.links && (
         <Links
@@ -54,4 +52,4 @@ const LoginIdScreen: React.FC = () => {
   );
 };
 
-export default LoginIdScreen;
+export default LoginScreen;

--- a/src/screens/LoginId/hooks/useLoginManager.ts
+++ b/src/screens/LoginId/hooks/useLoginManager.ts
@@ -1,27 +1,27 @@
 import { useState } from 'react';
 import LoginIdInstance from "@auth0/auth0-acul-js/login-id";
 
-export const useLoginIdManager = () => {
-  const [loginIdManager] = useState(() => new LoginIdInstance());
+export const useLoginManager = () => {
+  const [loginManager] = useState(() => new LoginIdInstance());
 
   const handleLogin = (username: string, captcha: string): void => {
     const options = {
       username,
-      captcha: loginIdManager.screen.isCaptchaAvailable ? captcha : "",
+      captcha: loginManager.screen.isCaptchaAvailable ? captcha : "",
     };
-    loginIdManager.login(options);
+    loginManager.login(options);
   };
 
   const handleSocialConnectionLogin = (connectionName: string) => {
-    loginIdManager.socialLogin({ connection: connectionName });
+    loginManager.socialLogin({ connection: connectionName });
   };
 
   const handlePasskeyLogin = () => {
-    loginIdManager.passkeyLogin();
+    loginManager.passkeyLogin();
   };
 
   return {
-    loginIdManager,
+    loginManager,
     handleLogin,
     handleSocialConnectionLogin,
     handlePasskeyLogin,

--- a/src/screens/LoginId/index.tsx
+++ b/src/screens/LoginId/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLoginIdManager } from './hooks/useLoginIdManager';
+import { useLoginManager } from './hooks/useLoginManager';
 import { useLoginForm } from './hooks/useLoginForm';
 import { Logo } from "../../components/Logo";
 import { Title } from './components/Title';
@@ -10,7 +10,7 @@ import { Links } from './components/Links';
 import { ErrorMessages } from './components/ErrorMessages';
 
 const LoginIdScreen: React.FC = () => {
-  const { loginIdManager, handleLogin, handleSocialConnectionLogin, handlePasskeyLogin } = useLoginIdManager();
+  const { loginManager, handleLogin, handleSocialConnectionLogin, handlePasskeyLogin } = useLoginManager();
   const { usernameRef, captchaRef, getFormValues } = useLoginForm();
 
   const onLoginClick = () => {
@@ -21,34 +21,34 @@ const LoginIdScreen: React.FC = () => {
   return (
     <div className="prompt-container">
       <Logo />
-      <Title screenTexts={loginIdManager.screen.texts!} />
+      <Title screenTexts={loginManager.screen.texts!} />
       
       <LoginForm
         usernameRef={usernameRef}
         captchaRef={captchaRef}
-        isCaptchaAvailable={loginIdManager.screen.isCaptchaAvailable}
-        captchaImage={loginIdManager.screen.captchaImage!}
-        countryCode={loginIdManager.transaction.countryCode!}
-        countryPrefix={loginIdManager.transaction.countryPrefix!}
+        isCaptchaAvailable={loginManager.screen.isCaptchaAvailable}
+        captchaImage={loginManager.screen.captchaImage!}
+        countryCode={loginManager.transaction.countryCode!}
+        countryPrefix={loginManager.transaction.countryPrefix!}
         onLoginClick={onLoginClick}
       />
 
       <SocialLogin
-        connections={loginIdManager.transaction.alternateConnections!}
+        connections={loginManager.transaction.alternateConnections!}
         onSocialLogin={handleSocialConnectionLogin}
       />
 
       <PasskeyButton onPasskeyLogin={handlePasskeyLogin} />
 
-      {loginIdManager.screen.links && (
+      {loginManager.screen.links && (
         <Links
-          signupLink={loginIdManager.screen.signupLink!}
-          resetPasswordLink={loginIdManager.screen.resetPasswordLink!}
+          signupLink={loginManager.screen.signupLink!}
+          resetPasswordLink={loginManager.screen.resetPasswordLink!}
         />
       )}
 
-      {loginIdManager.transaction.hasErrors && loginIdManager.transaction.errors && (
-        <ErrorMessages errors={loginIdManager.transaction.errors!} />
+      {loginManager.transaction.hasErrors && loginManager.transaction.errors && (
+        <ErrorMessages errors={loginManager.transaction.errors!} />
       )}
     </div>
   );

--- a/src/screens/LoginPassword/hooks/useLoginPasswordManager.ts
+++ b/src/screens/LoginPassword/hooks/useLoginPasswordManager.ts
@@ -4,12 +4,12 @@ import LoginPasswordInstance from "@auth0/auth0-acul-js/login-password";
 export const useLoginPasswordManager = () => {
   const [loginPasswordManager] = useState(() => new LoginPasswordInstance());
 
-  const username = loginPasswordManager.untrustedData.getAuthParams()?.loginHint || "";
+  const username = loginPasswordManager.screen.data?.username || "";
   const isCaptchaAvailable = loginPasswordManager.screen.isCaptchaAvailable;
   const captchaImage = loginPasswordManager.screen.captchaImage;
-  const screenLinks = loginPasswordManager.screen.getScreenLinks();
+  const screenLinks = loginPasswordManager.screen.links;
   const { signupLink, resetPasswordLink } = loginPasswordManager.screen;
-  const errors = loginPasswordManager.transaction.hasErrors ? loginPasswordManager.transaction.getErrors() : null;
+  const errors = loginPasswordManager.transaction.hasErrors ? loginPasswordManager.transaction.errors : null;
 
   const login = (options: { username: string; password: string; captcha: string }) => {
     loginPasswordManager.login(options);

--- a/src/screens/ResetPassword/components/ErrorMessages.tsx
+++ b/src/screens/ResetPassword/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/screens/ResetPassword/components/Links.tsx
+++ b/src/screens/ResetPassword/components/Links.tsx
@@ -1,0 +1,11 @@
+interface LinksProps {
+  signupLink?: string;
+  resetPasswordLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ signupLink, resetPasswordLink }) => (
+  <div className="links">
+    {signupLink && <a href={signupLink}>Sign Up</a>}
+    {resetPasswordLink && <a href={resetPasswordLink}>Forgot Password?</a>}
+  </div>
+); 

--- a/src/screens/ResetPassword/components/LoginForm.tsx
+++ b/src/screens/ResetPassword/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 import  Button  from '../../../components/Button';
 interface LoginFormProps {
-  usernameRef: React.RefObject<HTMLInputElement>;
-  passwordRef: React.RefObject<HTMLInputElement>;
+  newPasswordRef: React.RefObject<HTMLInputElement>;
+  confirmPasswordRef: React.RefObject<HTMLInputElement>;
   captchaRef: React.RefObject<HTMLInputElement>;
   isCaptchaAvailable: boolean;
   captchaImage?: string;
@@ -11,31 +11,26 @@ interface LoginFormProps {
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({
-  usernameRef,
-  passwordRef,
+  newPasswordRef,
+  confirmPasswordRef,
   captchaRef,
   isCaptchaAvailable,
   captchaImage,
-  countryCode,
-  countryPrefix,
   onLoginClick,
 }) => (
   <div className="input-container">
-    <button className="pick-country-code hidden" id="pick-country-code">
-      Pick country code - {countryCode}: +{countryPrefix}
-    </button>
-    <label>Enter your email</label>
+    <label>Enter your new password</label>
     <input
-      type="text"
-      id="username"
-      ref={usernameRef}
+      type="password"
+      id="newPassword"
+      ref={newPasswordRef}
       placeholder="Enter your email"
     />
-    <label>Enter your password</label>
+    <label>Confirm your new password</label>
     <input
       type="password"
       id="password"
-      ref={passwordRef}
+      ref={confirmPasswordRef}
       placeholder="Enter your password"
     />
 

--- a/src/screens/ResetPassword/components/Title.tsx
+++ b/src/screens/ResetPassword/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/screens/ResetPassword/hooks/useLoginForm.ts
+++ b/src/screens/ResetPassword/hooks/useLoginForm.ts
@@ -1,0 +1,20 @@
+import { useRef } from 'react';
+
+export const useLoginForm = () => {
+  const newPasswordRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
+  const captchaRef = useRef<HTMLInputElement>(null);
+
+  const getFormValues = () => ({
+    newPassword: newPasswordRef.current?.value ?? "",
+    confirmPassword: confirmPasswordRef.current?.value ?? "",
+    captcha: captchaRef.current?.value ?? "",
+  });
+
+  return {
+    newPasswordRef,
+    confirmPasswordRef,
+    captchaRef,
+    getFormValues,
+  };
+};

--- a/src/screens/ResetPassword/hooks/useResetPasswordManager.ts
+++ b/src/screens/ResetPassword/hooks/useResetPasswordManager.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import ResetPassword from "@auth0/auth0-acul-js/reset-password";
+import { withWindowDebug } from "../../../utils";
+
+export const useResetPasswordManager = () => {
+  const [resetPasswordManager] = useState(() => new ResetPassword());
+  withWindowDebug(resetPasswordManager, 'resetPassword')
+
+  const handleResetPassword = (newPassword: string, confirmPassword: string, captcha: string): void => {
+    const options = {
+      'password-reset': newPassword,
+      're-enter-password': confirmPassword,
+      captcha: resetPasswordManager.screen.isCaptchaAvailable ? captcha : "",
+    };
+    resetPasswordManager.resetPassword(options);
+  };
+
+  return {
+    resetPasswordManager,
+    handleResetPassword
+  };
+};
+

--- a/src/screens/ResetPassword/index.tsx
+++ b/src/screens/ResetPassword/index.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useResetPasswordManager } from './hooks/useResetPasswordManager';
+import { useLoginForm } from './hooks/useLoginForm';
+import { Logo } from "../../components/Logo";
+import { Title } from './components/Title';
+import { LoginForm } from './components/LoginForm';
+import { ErrorMessages } from './components/ErrorMessages';
+
+const ResetPasswordScreen: React.FC = () => {
+  const { resetPasswordManager, handleResetPassword } = useResetPasswordManager();
+  const { newPasswordRef, confirmPasswordRef, captchaRef, getFormValues } = useLoginForm();
+
+  const onLoginClick = () => {
+    const { newPassword, confirmPassword, captcha } = getFormValues();
+    handleResetPassword(newPassword, confirmPassword, captcha);
+  };
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={resetPasswordManager.screen.texts!} />
+      
+      <LoginForm
+        newPasswordRef={newPasswordRef}
+        confirmPasswordRef={confirmPasswordRef}
+        captchaRef={captchaRef}
+        isCaptchaAvailable={resetPasswordManager.screen.isCaptchaAvailable}
+        captchaImage={resetPasswordManager.screen.captchaImage!}
+        countryCode={resetPasswordManager.transaction.countryCode!}
+        countryPrefix={resetPasswordManager.transaction.countryPrefix!}
+        onLoginClick={onLoginClick}
+      />
+
+      {resetPasswordManager.transaction.hasErrors && resetPasswordManager.transaction.errors && (
+        <ErrorMessages errors={resetPasswordManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default ResetPasswordScreen;

--- a/src/screens/ResetPasswordEmail/components/ResetPasswordRequest.tsx
+++ b/src/screens/ResetPasswordEmail/components/ResetPasswordRequest.tsx
@@ -1,0 +1,16 @@
+import  Button  from '../../../components/Button';
+interface ResetPasswordRequest {
+  onLoginClick: () => void;
+}
+
+export const ResetPasswordRequest: React.FC<ResetPasswordRequest> = ({
+  onLoginClick,
+}) => (
+  <div className="input-container">
+    <label>Check Your Email</label>
+    <div className="button-container">
+      <Button onClick={onLoginClick}>Resend Email</Button>
+    </div>
+  
+  </div>
+); 

--- a/src/screens/ResetPasswordEmail/hooks/useResetPasswordEmailManager.ts
+++ b/src/screens/ResetPasswordEmail/hooks/useResetPasswordEmailManager.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import ResetPasswordEmailInstance from "@auth0/auth0-acul-js/reset-password-email";
+import { withWindowDebug } from "../../../utils";
+
+export const useResetPasswordRequestManager = () => {
+  const resetPasswordEmailInstance  = new ResetPasswordEmailInstance()
+  const [resetPasswordRequestManager] = useState(resetPasswordEmailInstance);
+  withWindowDebug(resetPasswordEmailInstance, 'resetPasswordEmail')
+
+  const resendEmail = (): void => {
+    resetPasswordRequestManager.resendEmail();
+  };
+
+  const getScreenText = () => {
+    return {
+      title:resetPasswordRequestManager.screen.texts?.title,
+      description : resetPasswordRequestManager.screen.texts?.usernameDescription
+    }
+  };
+
+  return {
+    resetPasswordRequestManager,
+    resendEmail,
+    getScreenText
+  };
+};
+

--- a/src/screens/ResetPasswordEmail/index.tsx
+++ b/src/screens/ResetPasswordEmail/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { useResetPasswordRequestManager } from './hooks/useResetPasswordEmailManager';
+import { Logo } from "../../components/Logo";
+import { Title } from '../../components/Title';
+import { ResetPasswordRequest } from './components/ResetPasswordRequest';
+import { Links } from '../../components/Links';
+import { ErrorMessages } from '../../components/ErrorMessages';
+
+const SignupScreen: React.FC = () => {
+  const { resetPasswordRequestManager, resendEmail, getScreenText } = useResetPasswordRequestManager();
+
+  const onUserLoginClick = () => {
+    resendEmail();
+  };
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={getScreenText()} />
+      
+      <ResetPasswordRequest
+        onLoginClick={onUserLoginClick}
+      />
+      {resetPasswordRequestManager.screen.links && (
+        <Links
+          loginLink={resetPasswordRequestManager.screen.links.loginLink!}
+        />
+      )}
+
+      {resetPasswordRequestManager.transaction.hasErrors && resetPasswordRequestManager.transaction.errors && (
+        <ErrorMessages errors={resetPasswordRequestManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default SignupScreen;

--- a/src/screens/ResetPasswordError/components/ErrorMessages.tsx
+++ b/src/screens/ResetPasswordError/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/screens/ResetPasswordError/components/Links.tsx
+++ b/src/screens/ResetPasswordError/components/Links.tsx
@@ -1,0 +1,11 @@
+interface LinksProps {
+  signupLink?: string;
+  resetPasswordLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ signupLink, resetPasswordLink }) => (
+  <div className="links">
+    {signupLink && <a href={signupLink}>Sign Up</a>}
+    {resetPasswordLink && <a href={resetPasswordLink}>Forgot Password?</a>}
+  </div>
+); 

--- a/src/screens/ResetPasswordError/components/LoginForm.tsx
+++ b/src/screens/ResetPasswordError/components/LoginForm.tsx
@@ -1,0 +1,54 @@
+import  Button  from '../../../components/Button';
+interface LoginFormProps {
+  newPasswordRef: React.RefObject<HTMLInputElement>;
+  confirmPasswordRef: React.RefObject<HTMLInputElement>;
+  captchaRef: React.RefObject<HTMLInputElement>;
+  isCaptchaAvailable: boolean;
+  captchaImage?: string;
+  countryCode?: string;
+  countryPrefix?: string;
+  onLoginClick: () => void;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({
+  newPasswordRef,
+  confirmPasswordRef,
+  captchaRef,
+  isCaptchaAvailable,
+  captchaImage,
+  onLoginClick,
+}) => (
+  <div className="input-container">
+    <label>Enter your new password</label>
+    <input
+      type="password"
+      id="newPassword"
+      ref={newPasswordRef}
+      placeholder="Enter your email"
+    />
+    <label>Confirm your new password</label>
+    <input
+      type="password"
+      id="password"
+      ref={confirmPasswordRef}
+      placeholder="Enter your password"
+    />
+
+    {isCaptchaAvailable && (
+      <div className="captcha-container">
+        <img src={captchaImage ?? ""} alt="Captcha" />
+        <label>Enter the captcha</label>
+        <input
+          type="text"
+          id="captcha"
+          ref={captchaRef}
+          placeholder="Enter the captcha"
+        />
+      </div>
+    )}
+
+    <div className="button-container">
+      <Button id="continue" onClick={onLoginClick}>Continue</Button>
+    </div>
+  </div>
+); 

--- a/src/screens/ResetPasswordError/components/Title.tsx
+++ b/src/screens/ResetPasswordError/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/screens/ResetPasswordError/hooks/useResetPasswordErrorManager.ts
+++ b/src/screens/ResetPasswordError/hooks/useResetPasswordErrorManager.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import ResetPasswordError from "@auth0/auth0-acul-js/reset-password-error";
+import { withWindowDebug } from "../../../utils";
+
+export const useResetPasswordErrorManager = () => {
+  const [resetPasswordErrorManager] = useState(() => new ResetPasswordError());
+  withWindowDebug(resetPasswordErrorManager, 'resetPasswordError')
+
+  return {
+    resetPasswordErrorManager
+  };
+};
+

--- a/src/screens/ResetPasswordError/index.tsx
+++ b/src/screens/ResetPasswordError/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useResetPasswordErrorManager } from './hooks/useResetPasswordErrorManager';
+import { Logo } from "../../components/Logo";
+import { Title } from './components/Title';
+import { ErrorMessages } from './components/ErrorMessages';
+
+const ResetPasswordScreen: React.FC = () => {
+  const { resetPasswordErrorManager } = useResetPasswordErrorManager();
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={resetPasswordErrorManager.screen.texts!} />
+      
+      <p>{ resetPasswordErrorManager.screen.texts?.description }</p>
+
+      {resetPasswordErrorManager.transaction.hasErrors && resetPasswordErrorManager.transaction.errors && (
+        <ErrorMessages errors={resetPasswordErrorManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default ResetPasswordScreen;

--- a/src/screens/ResetPasswordRequest/components/ResetPasswordRequest.tsx
+++ b/src/screens/ResetPasswordRequest/components/ResetPasswordRequest.tsx
@@ -1,0 +1,28 @@
+import  Button  from '../../../components/Button';
+interface ResetPasswordRequest {
+  usernameRef: React.RefObject<HTMLInputElement>;
+  onBackClick: () => void;
+  onLoginClick: () => void;
+}
+
+export const ResetPasswordRequest: React.FC<ResetPasswordRequest> = ({
+  usernameRef,
+  onBackClick,
+  onLoginClick,
+}) => (
+  <div className="input-container">
+    <label>Enter your username</label>
+    <input
+      type="text"
+      id="username"
+      ref={usernameRef}
+      placeholder="Enter your username"
+    />
+    <div className="button-container">
+      <Button onClick={onLoginClick}>Continue</Button>
+    </div>
+    <div className="button-container">
+      <Button onClick={onBackClick}>Back To My App</Button>
+    </div>
+  </div>
+); 

--- a/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestForm.ts
+++ b/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestForm.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+export const useResetPasswordRequestForm = () => {
+  const usernameRef = useRef<HTMLInputElement>(null);
+  const phoneNumberRef = useRef<HTMLInputElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const captchaRef = useRef<HTMLInputElement>(null);
+
+  const getFormValues = () => ({
+    username: usernameRef.current?.value ?? "",
+    phoneNumber: phoneNumberRef.current?.value ?? "",
+    email: emailRef.current?.value ?? "",
+    password: passwordRef.current?.value ?? "",
+    captcha: captchaRef.current?.value ?? "",
+  });
+
+  return {
+    usernameRef,
+    phoneNumberRef,
+    emailRef,
+    passwordRef,
+    captchaRef,
+    getFormValues,
+  };
+};

--- a/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestManager.ts
+++ b/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestManager.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import ResetPasswordRequestInstance from "@auth0/auth0-acul-js/reset-password-request";
+import { ResetPasswordRequestOptions } from "@auth0/auth0-acul-js/reset-password-request";
+import { withWindowDebug } from "../../../utils";
+
+export const useResetPasswordRequestManager = () => {
+  const resetPasswordRequestInstance  = new ResetPasswordRequestInstance()
+  const [resetPasswordRequestManager] = useState(resetPasswordRequestInstance);
+  withWindowDebug(resetPasswordRequestInstance, 'resetPasswordRequest')
+
+  const continueWithIdentifier = (options: ResetPasswordRequestOptions): void => {
+    const payload: ResetPasswordRequestOptions = {
+      username: options.username
+    }
+    resetPasswordRequestManager.continueWithIdentifier(payload);
+  };
+
+  const backToLogin = () => {
+    resetPasswordRequestManager.backToLogin();
+  };
+
+  return {
+    resetPasswordRequestManager,
+    continueWithIdentifier,
+    backToLogin
+  };
+};
+

--- a/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestManager.ts
+++ b/src/screens/ResetPasswordRequest/hooks/useResetPasswordRequestManager.ts
@@ -12,7 +12,7 @@ export const useResetPasswordRequestManager = () => {
     const payload: ResetPasswordRequestOptions = {
       username: options.username
     }
-    resetPasswordRequestManager.continueWithIdentifier(payload);
+    resetPasswordRequestManager.resetPassword(payload);
   };
 
   const backToLogin = () => {

--- a/src/screens/ResetPasswordRequest/index.tsx
+++ b/src/screens/ResetPasswordRequest/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useResetPasswordRequestManager } from './hooks/useResetPasswordRequestManager';
+import { useResetPasswordRequestForm } from './hooks/useResetPasswordRequestForm';
+import { Logo } from "../../components/Logo";
+import { Title } from '../../components/Title';
+import { ResetPasswordRequest } from './components/ResetPasswordRequest';
+import { Links } from '../../components/Links';
+import { ErrorMessages } from '../../components/ErrorMessages';
+
+const SignupScreen: React.FC = () => {
+  const { resetPasswordRequestManager, continueWithIdentifier, backToLogin } = useResetPasswordRequestManager();
+  const { usernameRef, getFormValues } = useResetPasswordRequestForm();
+
+  const onUserLoginClick = () => {
+    const { username } = getFormValues();
+    continueWithIdentifier({username});
+  };
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={resetPasswordRequestManager.screen.texts!} />
+      
+      <ResetPasswordRequest
+        usernameRef={usernameRef}
+        onLoginClick={onUserLoginClick}
+        onBackClick={backToLogin}
+      />
+      {resetPasswordRequestManager.screen.links && (
+        <Links
+          loginLink={resetPasswordRequestManager.screen.links.loginLink!}
+        />
+      )}
+
+      {resetPasswordRequestManager.transaction.hasErrors && resetPasswordRequestManager.transaction.errors && (
+        <ErrorMessages errors={resetPasswordRequestManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default SignupScreen;

--- a/src/screens/ResetPasswordSuccess/components/ErrorMessages.tsx
+++ b/src/screens/ResetPasswordSuccess/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/screens/ResetPasswordSuccess/components/Links.tsx
+++ b/src/screens/ResetPasswordSuccess/components/Links.tsx
@@ -1,0 +1,11 @@
+interface LinksProps {
+  signupLink?: string;
+  resetPasswordLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ signupLink, resetPasswordLink }) => (
+  <div className="links">
+    {signupLink && <a href={signupLink}>Sign Up</a>}
+    {resetPasswordLink && <a href={resetPasswordLink}>Forgot Password?</a>}
+  </div>
+); 

--- a/src/screens/ResetPasswordSuccess/components/Title.tsx
+++ b/src/screens/ResetPasswordSuccess/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/screens/ResetPasswordSuccess/hooks/useResetPasswordSuccessManager.ts
+++ b/src/screens/ResetPasswordSuccess/hooks/useResetPasswordSuccessManager.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import ResetPasswordSuccess from "@auth0/auth0-acul-js/reset-password-error";
+import { withWindowDebug } from "../../../utils";
+
+export const useResetPasswordSuccessManager = () => {
+  const [resetPasswordSuccessManager] = useState(() => new ResetPasswordSuccess());
+  withWindowDebug(resetPasswordSuccessManager, 'resetPasswordSuccess')
+
+  return {
+    resetPasswordSuccessManager
+  };
+};
+

--- a/src/screens/ResetPasswordSuccess/index.tsx
+++ b/src/screens/ResetPasswordSuccess/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useResetPasswordSuccessManager } from './hooks/useResetPasswordSuccessManager';
+import { Logo } from "../../components/Logo";
+import { Title } from './components/Title';
+import { ErrorMessages } from './components/ErrorMessages';
+
+const ResetPasswordScreen: React.FC = () => {
+  const { resetPasswordSuccessManager } = useResetPasswordSuccessManager();
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={resetPasswordSuccessManager.screen.texts!} />
+      
+      <p>{ resetPasswordSuccessManager.screen.texts?.description }</p>
+
+      {resetPasswordSuccessManager.transaction.hasErrors && resetPasswordSuccessManager.transaction.errors && (
+        <ErrorMessages errors={resetPasswordSuccessManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default ResetPasswordScreen;

--- a/src/screens/Signup/components/ErrorMessages.tsx
+++ b/src/screens/Signup/components/ErrorMessages.tsx
@@ -1,0 +1,15 @@
+interface Error {
+  message?: string;
+}
+
+interface ErrorMessagesProps {
+  errors?: Error[];
+}
+
+export const ErrorMessages: React.FC<ErrorMessagesProps> = ({ errors }) => (
+  <div className="error-container">
+    {errors?.map((error, index) => (
+      <p key={index}>{error?.message}</p>
+    ))}
+  </div>
+); 

--- a/src/screens/Signup/components/Links.tsx
+++ b/src/screens/Signup/components/Links.tsx
@@ -1,0 +1,9 @@
+interface LinksProps {
+  loginLink?: string;
+}
+
+export const Links: React.FC<LinksProps> = ({ loginLink }) => (
+  <div className="links">
+    {loginLink && <a href={loginLink}>Sign Up</a>}
+  </div>
+); 

--- a/src/screens/Signup/components/LoginForm.tsx
+++ b/src/screens/Signup/components/LoginForm.tsx
@@ -1,0 +1,77 @@
+import  Button  from '../../../components/Button';
+interface LoginFormProps {
+  emailRef: React.RefObject<HTMLInputElement>;
+  usernameRef: React.RefObject<HTMLInputElement>;
+  phoneNumberRef: React.RefObject<HTMLInputElement>;
+  passwordRef: React.RefObject<HTMLInputElement>;
+  captchaRef: React.RefObject<HTMLInputElement>;
+  isCaptchaAvailable: boolean;
+  captchaImage?: string;
+  countryCode?: string;
+  countryPrefix?: string;
+  onLoginClick: () => void;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({
+  emailRef,
+  usernameRef,
+  phoneNumberRef,
+  passwordRef,
+  captchaRef,
+  isCaptchaAvailable,
+  captchaImage,
+  countryCode,
+  countryPrefix,
+  onLoginClick,
+}) => (
+  <div className="input-container">
+    <button className="pick-country-code hidden" id="pick-country-code">
+      Pick country code - {countryCode}: +{countryPrefix}
+    </button>
+    <label>Enter your email</label>
+    <input
+      type="email"
+      id="email"
+      ref={emailRef}
+      placeholder="Enter your email"
+    />
+    <label>Enter your username</label>
+    <input
+      type="text"
+      id="username"
+      ref={usernameRef}
+      placeholder="Enter your username"
+    />
+    <label>Enter your phone number</label>
+    <input
+      type="tel"
+      id="phoneNumber"
+      ref={phoneNumberRef}
+      placeholder="Enter your phone number"
+    />
+    <label>Enter your password</label>
+    <input
+      type="password"
+      id="password"
+      ref={passwordRef}
+      placeholder="Enter your password"
+    />
+
+    {isCaptchaAvailable && (
+      <div className="captcha-container">
+        <img src={captchaImage ?? ""} alt="Captcha" />
+        <label>Enter the captcha</label>
+        <input
+          type="text"
+          id="captcha"
+          ref={captchaRef}
+          placeholder="Enter the captcha"
+        />
+      </div>
+    )}
+
+    <div className="button-container">
+      <Button onClick={onLoginClick}>Continue</Button>
+    </div>
+  </div>
+); 

--- a/src/screens/Signup/components/SocialLogin.tsx
+++ b/src/screens/Signup/components/SocialLogin.tsx
@@ -1,0 +1,22 @@
+import  Button  from '../../../components/Button';
+interface Connection {
+  name: string;
+}
+
+interface SocialLoginProps {
+  connections?: Connection[];
+  onSocialLogin: (name: string) => void;
+}
+
+export const SocialLogin: React.FC<SocialLoginProps> = ({ connections, onSocialLogin }) => (
+  <div className="federated-login-container">
+    {connections?.map((connection) => (
+      <Button
+        key={connection.name}
+        onClick={() => onSocialLogin(connection.name)}
+      >
+        Continue with {connection.name}
+      </Button>
+    ))}
+  </div>
+); 

--- a/src/screens/Signup/components/Title.tsx
+++ b/src/screens/Signup/components/Title.tsx
@@ -1,0 +1,13 @@
+interface TitleProps {
+  screenTexts: {
+    title?: string;
+    description?: string;
+  };
+}
+
+export const Title: React.FC<TitleProps> = ({ screenTexts }) => (
+  <div className="title-container">
+    <h1>{screenTexts?.title}</h1>
+    <p>{screenTexts?.description}</p>
+  </div>
+); 

--- a/src/screens/Signup/hooks/useSignupForm.ts
+++ b/src/screens/Signup/hooks/useSignupForm.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+export const useSignupForm = () => {
+  const usernameRef = useRef<HTMLInputElement>(null);
+  const phoneNumberRef = useRef<HTMLInputElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const captchaRef = useRef<HTMLInputElement>(null);
+
+  const getFormValues = () => ({
+    username: usernameRef.current?.value ?? "",
+    phoneNumber: phoneNumberRef.current?.value ?? "",
+    email: emailRef.current?.value ?? "",
+    password: passwordRef.current?.value ?? "",
+    captcha: captchaRef.current?.value ?? "",
+  });
+
+  return {
+    usernameRef,
+    phoneNumberRef,
+    emailRef,
+    passwordRef,
+    captchaRef,
+    getFormValues,
+  };
+};

--- a/src/screens/Signup/hooks/useSignupManager.ts
+++ b/src/screens/Signup/hooks/useSignupManager.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import LoginInstance from "@auth0/auth0-acul-js/signup";
+
+export const useSignupManager = () => {
+  const [signupManager] = useState(() => new LoginInstance());
+
+  const handleSignup = (username: string, email: string, phoneNumber: string,  password: string, captcha: string): void => {
+    const options = {
+      username,
+      email,
+      phoneNumber,
+      password,
+      captcha: signupManager.screen.isCaptchaAvailable ? captcha : "",
+    };
+    signupManager.signup(options);
+  };
+
+  const handleSocialSignup = (connectionName: string) => {
+    signupManager.socialSignup({ connection: connectionName });
+  };
+
+  return {
+    signupManager,
+    handleSignup,
+    handleSocialSignup
+  };
+};
+

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { useSignupManager } from './hooks/useSignupManager';
+import { useSignupForm } from './hooks/useSignupForm';
+import { Logo } from "../../components/Logo";
+import { Title } from './components/Title';
+import { LoginForm } from './components/LoginForm';
+import { SocialLogin } from './components/SocialLogin';
+import { Links } from './components/Links';
+import { ErrorMessages } from './components/ErrorMessages';
+
+const SignupScreen: React.FC = () => {
+  const { signupManager, handleSignup, handleSocialSignup } = useSignupManager();
+  const { emailRef, usernameRef, phoneNumberRef, passwordRef, captchaRef, getFormValues } = useSignupForm();
+
+  const onLoginClick = () => {
+    const { username, email, phoneNumber, password, captcha } = getFormValues();
+    handleSignup(username, email, phoneNumber, password, captcha);
+  };
+
+  return (
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={signupManager.screen.texts!} />
+      
+      <LoginForm
+        emailRef={emailRef}
+        usernameRef={usernameRef}
+        phoneNumberRef={phoneNumberRef}
+        passwordRef={passwordRef}
+        captchaRef={captchaRef}
+        isCaptchaAvailable={signupManager.screen.isCaptchaAvailable}
+        captchaImage={signupManager.screen.captchaImage!}
+        countryCode={signupManager.transaction.countryCode!}
+        countryPrefix={signupManager.transaction.countryPrefix!}
+        onLoginClick={onLoginClick}
+      />
+
+      <SocialLogin
+        connections={signupManager.transaction.alternateConnections!}
+        onSocialLogin={handleSocialSignup}
+      />
+
+      {signupManager.screen.links && (
+        <Links
+          loginLink={signupManager.screen.links.loginLink!}
+        />
+      )}
+
+      {signupManager.transaction.hasErrors && signupManager.transaction.errors && (
+        <ErrorMessages errors={signupManager.transaction.errors!} />
+      )}
+    </div>
+  );
+};
+
+export default SignupScreen;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,4 @@
+export const withWindowDebug = <T extends object>(manager: T, debugKey: string): T => {
+      (window as any)[debugKey] = manager;
+    return manager;
+  };


### PR DESCRIPTION
## Added Release-2 Related Screen Support

- Added support for the following screens as part of Release-2:

[login](https://auth0.github.io/universal-login/classes/Classes.Login.html)
[signup](https://auth0.github.io/universal-login/classes/Classes.Signup.html)
[reset-password-email](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordEmail.html)
[reset-password-request](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordRequest.html)
[reset-password](https://auth0.github.io/universal-login/classes/Classes.ResetPassword.html)
[reset-password-error](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordError.html)
[reset-password-success](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordSuccess.html)

### Changes:
- Implemented UI and functionality for each of the above screens.
- Updated routing and navigation to include new screens.
- Ensured consistency with the existing design and user flow.