### PR TITLE
Fix: Pass code as an object to continue method in MFA recovery screen

### DIFF
--- a/src/screens/mfa-recovery-code-challenge/index.tsx
+++ b/src/screens/mfa-recovery-code-challenge/index.tsx
@@ -9,7 +9,7 @@ const MfaRecoveryCodeChallengeScreen: React.FC = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    mfaRecoveryCodeChallenge.continue(code);
+    mfaRecoveryCodeChallenge.continue({ code });
   };
 
   const handleTryAnotherMethod = () => {


### PR DESCRIPTION
Updated the `handleSubmit` function in `src/screens/mfa-recovery-code-challenge/index.tsx` to correctly pass the `code` as an object to `mfaRecoveryCodeChallenge.continue`.

- Before: `mfaRecoveryCodeChallenge.continue(code);`
- After: `mfaRecoveryCodeChallenge.continue({ code });`

This change ensures the function receives the correct parameter format, preventing potential runtime issues and aligning with expected usage.
