### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/aws-publish.yml
+++ b/.github/workflows/aws-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Step 3: Install dependencies
       - name: Install dependencies
-        run: npm ci --include=dev
+        run: npm ci --ignore-scripts --include=dev
 
       # Step 4: Build the project
       - name: Build package


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI